### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ it, simply add the following line to your Podfile and run `pod install` from the
 pod "gujemsiossdk"
 ```
 
-Make sure you have a recent version of Cocoa Pods installed. We used version 0.38.2 and saw problems with older version of Cocoa Pods.
+Make sure you have a recent version of CocoaPods installed. We used version 0.38.2 and saw problems with older version of CocoaPods.
 
-If you don't have CocoaPods installed so far, check the [Cocoa Pods documentation](https://guides.cocoapods.org/using/using-cocoapods.html).  
+If you don't have CocoaPods installed so far, check the [CocoaPods documentation](https://guides.cocoapods.org/using/using-cocoapods.html).  
 If you don't want to use CocoaPods you should be able to copy the classes from this workspace and manually add 
 the dependencies like we did in `gujemsiossdk.podspec`. Anyway we do not recommend to do the installation without CocoaPods.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
