### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 The SDK supports **iOS 7.0 and higher**.  
 Language Support: **Objective-C**  
-Use **xCode 5.0 or higher**.
+Use **Xcode 5.0 or higher**.
 
 
 ## Installation


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
