### PR TITLE
Update Google-Mobile-Ads-SDK from 7.16.0 to 7.24

### DIFF
--- a/gujemsiossdk.podspec
+++ b/gujemsiossdk.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Pod/Classes/*.h'
   s.frameworks = 'CoreMedia', 'UIKit', 'AVFoundation', 'AdSupport', 'StoreKit', 'CoreMotion', 'CoreLocation', 'CoreTelephony', 'MediaPlayer', 'SystemConfiguration'
   s.libraries = 'xml2'
-  s.dependency 'Google-Mobile-Ads-SDK', '7.16.0'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 7.24'
   s.dependency 'GoogleAds-IMA-iOS-SDK-For-AdMob', '3.3.1'
 
 end


### PR DESCRIPTION
`Google-Mobile-Ads-SDK` calls UI code on a background thread, which will result in misplaced advertisings with your SDK.

Updating to the latest `Google-Mobile-Ads-SDK` (v7.24.1) removes this problem and advertisings are displayed as designed.

This PR doesn't update the example project and should be addressed separately.