### PR TITLE
Update dependency management to use latest release of Google-Mobile-Ads-SDK

### DIFF
--- a/gujemsiossdk.podspec
+++ b/gujemsiossdk.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Pod/Classes/*.h'
   s.frameworks = 'CoreMedia', 'UIKit', 'AVFoundation', 'AdSupport', 'StoreKit', 'CoreMotion', 'CoreLocation', 'CoreTelephony', 'MediaPlayer', 'SystemConfiguration'
   s.libraries = 'xml2'
-  s.dependency 'Google-Mobile-Ads-SDK', '7.24.1'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 7.0'
   s.dependency 'GoogleAds-IMA-iOS-SDK', '~> 3.6'
   s.dependency 'FBAudienceNetwork'
 


### PR DESCRIPTION
`Google-Mobile-Ads-SDK` was pinned to v7.24.1. Google updates its SDK consistently, which will not be used by the `gujemsiossdk`.

This PR changes the dependency to allow automatic updates from Google for v7.x, but doesn't update the example project (this should be addressed separately).